### PR TITLE
cleanup to pass html validator, add 2016 security deprecation warning.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,84 +1,82 @@
-<html>
+<!doctype html public "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/tr/html4/loose.dtd">
+<html lang="en">
 <head>
-<meta name="google-site-verification" content="tsC40Go6u6ldH1pmeafOZhKJc7v1dxGQ6lYzxqlkN2I" />
+<meta http-equiv="content-type" content="text/html; charset=utf-8">
+<meta name="google-site-verification" content="tsC40Go6u6ldH1pmeafOZhKJc7v1dxGQ6lYzxqlkN2I">
 <!--* Remote PwdHash Form
-      * An HTML form that calls the JavaScript implementation of PwdHash
-      * Version 1.0 Copyright (C) Stanford University 2004-2005
-      * Contributors: Dan Boneh, Collin Jackson, John Mitchell, Nick Miyake, and Blake Ross
-      * Distributed under the BSD License
-      * See http://crypto.stanford.edu/PwdHash for more info.
-      *-->
-  <title>PwdHash</title>
-  <script src="md5.js" type="text/javascript"></script>
-  <script src="pwdhash.js" type="text/javascript"></script>
-  <script src="hashed-password.js" type="text/javascript"></script>
-  <script src="domain-extractor.js" type="text/javascript"></script>
-  <link rel="stylesheet" type="text/css" href="pwdhash.css" />
-  <link rel="shortcut icon" href="favicon.ico" />
+* An HTML form that calls the JavaScript implementation of PwdHash
+* Version 1.0 Copyright (C) Stanford University 2004-2005
+* Contributors: Dan Boneh, Collin Jackson, John Mitchell, Nick Miyake, and Blake Ross
+* Distributed under the BSD License
+* See http://crypto.stanford.edu/PwdHash for more info.
+*-->
+<title>PwdHash</title>
+<script src="md5.js" type="text/javascript"></script>
+<script src="pwdhash.js" type="text/javascript"></script>
+<script src="hashed-password.js" type="text/javascript"></script>
+<script src="domain-extractor.js" type="text/javascript"></script>
+<link rel="stylesheet" type="text/css" href="pwdhash.css">
+<link rel="shortcut icon" href="favicon.ico">
 </head>
 <body onLoad="Init();">
-<table align=right style="margin: 3em 1em 1em 1em"><tr><td>
-<form name="hashform" action="error.html" method="POST"
-onsubmit="setTimeout('GenerateToTextField()', 0); return false;">
-<table id="theHashForm"><tr>
-<td class="stepList">
-<div class="step" id="theSiteDomain">
-<h3>Site Address</h3>
-<p><input type="text" name="domain"></p>
-</div>
-<div class="step" id="theSitePassword">
-<h3>Site Password</h3>
-<p><input type="password" name="sitePassword"></p>
-</div>
-</td>
-</tr>
+<form name="hashform" action="" method="post" onsubmit="setTimeout('GenerateToTextField()', 0); return false;">
+<table align="right" style="margin: 3em 1em 1em 1em" id="theHashForm">
 <tr>
-<td class="stepList" colspan="2">
-<div class="step" id="theHashedPassword">
-<h3>Hashed Password</h3>	
-  <span id="theGeneratePanel">
-    <input type="text" name="hashedPassword">
-    <input type="submit" name"submitButton" value="Generate">
-  </span>
-<p align="center"><a id="theToggleModeLink" href="javascript:ToggleAdvancedMode()"></a></p>
-</div>
+<td class="stepList">
+	<noscript>
+		<p>Please enable Javascript to use this.</p>
+	</noscript>
+	<div class="step" id="theSiteDomain">
+		<h3>Site Address</h3>
+		<p><input type="text" name="domain"></p>
+	</div>
+	<div class="step" id="theSitePassword">
+		<h3>Site Password</h3>
+		<p><input type="password" name="sitePassword"></p>
+	</div>
+	<div class="step" id="theHashedPassword">
+		<h3>Hashed Password</h3>
+		<input type="text" name="hashedPassword">
+		<input type="submit" name="submitButton" value="Generate">
+	</div>
+	<div class="footer">
+		<p>Version 0.8 (<a href="https://crypto.stanford.edu/PwdHash/RemotePwdHash/">more versions</a>)</p>
+		<p>Tip: You can save this page to disk.</p>
+	</div>
 </td>
 </tr>
 </table>
-</td></tr><tr><td><div class="footer">Version 0.8 (<a href="https://crypto.stanford.edu/PwdHash/RemotePwdHash/">more versions</a>)</div>
-<div class="footer">Tip: You can save this page to disk.</div>
-</td></tr></table>
-
-<p align="center"><img src="stanford_seal64.gif"
-   alt="Stanford" align="center" width="64" height="64"> </p>
-
-      <H1 align=center><font color="#0000FF" face="Arial">
-         Stanford PwdHash
-	    </font></H1>
-	            
+</form>
+<p align="center"><img src="stanford_seal64.gif" alt="Stanford" align="middle" width="64" height="64"></p>
+<h1 align="center"><font color="#0000FF" face="Arial">Stanford PwdHash</font></h1>
 <div id="theexplanation">
-<p>
-PwdHash generates theft-resistant passwords.
+<p>PwdHash generates theft-resistant passwords.
 The PwdHash browser extension invisibly generates these passwords when it is installed in your browser.
 You can activate this protection by pressing F2 before you type
 your password, or by choosing passwords that start with <tt>@@</tt>.
-If you don't want to install PwdHash on your computer, you can generate the passwords right here.
+If you don't want to install PwdHash on your computer, you can generate the passwords right here.</p>
 <ul>
-<li>Visit the <a href="http://crypto.stanford.edu/PwdHash/">Stanford project website</a>.</li>
-<li>Install
-<a href="https://addons.mozilla.org/en-US/firefox/addon/pwdhash/">PwdHash for Firefox</a>. It has been ported to <a href="https://chrome.google.com/extensions/detail/dnfmcfhnhnpoehjoommondmlmhdoonca">Chrome</a> and <a href="http://www.coredump.gr/pwdhash-for-opera/">Opera</a>.</li>
-<li>Read the <a href="http://crypto.stanford.edu/PwdHash/pwdhash.pdf">USENIX Security Symposium 2005 paper</a> (PDF).</li>
-<li>This site and plugin are no longer under active development and the <a href="http://github.com/collinjackson/pwdhash-website">code</a> is available for use. See individual files for license details.</li>
+	<li>Visit the <a href="http://crypto.stanford.edu/PwdHash/">Stanford project website</a>.</li>
+	<li>Read the <a href="http://crypto.stanford.edu/PwdHash/pwdhash.pdf">USENIX Security Symposium 2005 paper</a> (PDF).</li>
+	<li>The <a href="https://github.com/pwdhash/website">source code</a> is available for use, see individual files for license details.</li>
+	<li>Install browser add-on <a href="https://addons.mozilla.org/en-US/firefox/addon/pwdhash/">PwdHash for Firefox</a> or
+		<a href="https://chrome.google.com/webstore/detail/pwdhash-port/dnfmcfhnhnpoehjoommondmlmhdoonca">PwdHash for Chrome</a>.</li>
+	<li><b>This site and plugins are no longer under active development</b>, they should only be used for historical reference.</li>
+</ul>
+<h2><font color="#FF0000">SECURITY WARNING AS OF 2016:</font></h2>
+<ul>
+	<li>PwdHash never made it okay to start with a weak master password, and provides weak resistance against current technology.</li>
+	<li>You should migrate to a modern <b>and actively maintained</b> system as soon as possible.</li>
+	<li>View the <a href="http://www.flypig.co.uk/presentations/dlj-gr-passwords2016.pdf">Cracking PwdHash 2016 presentation</a> (PDF) or
+		read the <a href="http://www.flypig.co.uk/papers/dlj-gr-passwords16.pdf">Cracking PwdHash 2016 paper</a> (PDF).</li>
 </ul>
 </div>
-</form>
-<div style="text-align: center">
- Contributors: <a href="http://www.blakeross.com/">Blake Ross</a>,
-    <a href="http://www.collinjackson.com/">Collin Jackson</a>,
-      Nicholas Miyake,
-        <A href="http://crypto.stanford.edu/~dabo/">Dan Boneh</A> and <A 
-	  href="http://theory.stanford.edu/people/jcm/home.html">John C. 
-	    Mitchell</A>
+<div style="text-align: center">Contributors:
+	<a href="http://www.blakeross.com/">Blake Ross</a>,
+	<a href="http://www.collinjackson.com/">Collin Jackson</a>,
+	Nicholas Miyake,
+	<a href="http://crypto.stanford.edu/~dabo/">Dan Boneh</a>,
+	and <a href="http://theory.stanford.edu/people/jcm/home.html">John C. Mitchell</a>
 </div>
 </body>
 </html>


### PR DESCRIPTION
cleanup to pass html validator based on it appearing to have used HTML 4.01 Transitional when initially released, and seemed to be a strange mix of old and new returning too many w3c validator errors otherwise.

also add 2016 security deprecation warning, since this has not been a secure tool for a while, but is still useful as one of the historical academic examples of password generators which has since been superseded by much more modern systems.